### PR TITLE
Remove subtitle and Download CV link from about page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,14 +2,13 @@
 layout: about
 title: about
 permalink: /
-subtitle: Ph.D. Candidate | Machine Learning for 3D Perception & Robotic Autonomy
+subtitle:
 
 profile:
   align: right
   image: prof_pic.jpg
   image_circular: false # crops the image to make it circular
-  more_info: >
-    <a href="/assets/pdf/SandroPapais_CV.pdf" target="_blank">Download CV</a>
+  more_info:
 
 news: false # includes a list of news items
 selected_papers: true # includes a list of papers marked as "selected={true}"


### PR DESCRIPTION
## Summary

Clear the about page `subtitle` and the profile `more_info` Download CV link so the about header renders without them.

## Test plan

- [x] `npx prettier _pages/about.md --check` passes locally.
- [ ] About page renders without the subtitle line and the Download CV link.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfLByAhCC3nHKkCqkPkCi4)_