### PR TITLE
Default site theme to light mode

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -206,11 +206,11 @@ let transTheme = () => {
 };
 
 // Determine the expected state of the theme toggle, which can be "dark", "light", or
-// "system". Default is "system".
+// "system". Default is "light" so first-time visitors see the white background.
 let determineThemeSetting = () => {
   let themeSetting = localStorage.getItem("theme");
   if (themeSetting != "dark" && themeSetting != "light" && themeSetting != "system") {
-    themeSetting = "system";
+    themeSetting = "light";
   }
   return themeSetting;
 };


### PR DESCRIPTION
## Summary

Fall back to `"light"` instead of `"system"` in `determineThemeSetting()` so first-time visitors see the white background by default, regardless of their OS color scheme. Returning visitors and the manual toggle continue to use the value stored in `localStorage`.

## Test plan

- [ ] Load the site in a private window with `prefers-color-scheme: dark` set in DevTools and confirm it still renders light.
- [ ] Toggle to dark, reload, and confirm the dark choice persists.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfLByAhCC3nHKkCqkPkCi4)_