### PR TITLE
Add arXiv links for ForeSight and SWTrack

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -53,6 +53,7 @@
   booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV)},
   month     = {October},
   year      = {2025},
+  arxiv     = {2508.07089},
   preview   = {foresight.png},
   selected  = {true}
 }
@@ -64,6 +65,7 @@
   pages         = {4939--4945},
   year          = {2024},
   organization  = {IEEE},
+  arxiv         = {2402.17892},
   preview       = {swtrack.png},
   selected      = {true}
 }


### PR DESCRIPTION
## Summary

Add `arxiv = {2508.07089}` to ForeSight and `arxiv = {2402.17892}` to SWTrack so each entry renders the arXiv button alongside the other links.

## Test plan

- [ ] ForeSight and SWTrack entries show an arXiv button on the publications page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfLByAhCC3nHKkCqkPkCi4)_